### PR TITLE
make funding type configurable

### DIFF
--- a/bcclient/src/lib/bc/components/BudgetCalculatorPage.jsx
+++ b/bcclient/src/lib/bc/components/BudgetCalculatorPage.jsx
@@ -6,36 +6,44 @@ import BCWelcomeModal from './budgetcalculator/BCWelcomeModal';
 
 import BudgetContext from '../contexts/BudgetContext';
 
+import { bcConfig } from '../js/config';
+
 class BudgetCalculatorPage extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      showWelcome: true,//TODO: Set to false for debugging. Set to true for production
+      // welcome modal conditional on presetFundingType
+      showWelcome: bcConfig.presetFundingType === 'federal_rate' || bcConfig.presetFundingType === 'industry_rate' ? false : true
+      // showWelcome: true,//TODO: Set to false for debugging. Set to true for production
     }
+  }
+
+  welcomeOpenCallback = () => {
+    this.setState({showWelcome: true})
   }
 
   welcomeCallback = (fundingType) => {
     this.setState({showWelcome: false})
   }
-
   render() { 
     return ( 
       <BudgetProvider>
         <BudgetContext.Consumer>
           {context => (
             <>
-              <BudgetCalculator 
+              <BudgetCalculator
+                welcomeOpenCallback={this.welcomeOpenCallback} 
                 bcstate={context.bcstate}/>
               <BCWelcomeModal 
                 showWelcome={this.state.showWelcome} 
                 welcomeCallback={this.welcomeCallback} 
                 hideWelcome={this.handleHideWelcome} 
                 setFundingType={context.setFundingType}/>
+          {/* {console.log('bcrows in BC Page', context.bcrows)} */}
             </>
           )}
         </BudgetContext.Consumer>
 
-        
       </BudgetProvider>
      );
   }

--- a/bcclient/src/lib/bc/components/budgetcalculator/BCNav.jsx
+++ b/bcclient/src/lib/bc/components/budgetcalculator/BCNav.jsx
@@ -8,7 +8,8 @@ class BCNav extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      showInfoCallback: this.props.showInfoCallback
+      showInfoCallback: this.props.showInfoCallback,
+      welcomeOpenCallback: this.props.handleShowWelcome
     };
   }
 
@@ -16,10 +17,15 @@ class BCNav extends Component {
     this.state.showInfoCallback();
   }
 
+  handleShowWelcomeCallback = () => {
+    this.state.welcomeOpenCallback();
+  }
+
   handleDownloadAsPdfClick = () => {
     let downloader = new DownloadPdf();
     downloader.savePdf(this.props.bcstate);
   }
+
 
   render() { 
     return (
@@ -36,9 +42,11 @@ class BCNav extends Component {
         <a className="nav-link btn btn-lg font-weight-bolder bdgtcalc-nav" href="#/" onClick={this.handleEditBudgetInfoClick}>Edit Budget Information</a>
       </li>
       <li className="nav-item">
+        <a className="nav-link btn btn-lg font-weight-bolder bdgtcalc-nav" href="#/" onClick={this.handleShowWelcomeCallback}>Edit Rate</a>
+      </li>
+      <li className="nav-item">
         <a className="nav-link btn btn-lg font-weight-bolder bdgtcalc-nav" href="#/" onClick={this.handleDownloadAsPdfClick}>Download as PDF</a>
       </li>
-
     </ul>
   </div>
 </nav>

--- a/bcclient/src/lib/bc/components/budgetcalculator/BCWelcomeModal.jsx
+++ b/bcclient/src/lib/bc/components/budgetcalculator/BCWelcomeModal.jsx
@@ -28,12 +28,16 @@ class BCWelcomeModal extends Component {
   }
 
   render() { 
+    
+    
     return (
       <Modal id="welcomeModal" centered backdrop="static" show={this.props.showWelcome} aria-labelledby="welcomeModal" aria-hidden="true">
           <div role="document">
             <Form id="welcomeForm" onSubmit={this.handleSubmit}>
             <Modal.Body>
-              <p>Thank you for using the Budget Calculator! Please provide the following information to get started.</p>
+              {/* reword this for using it both at the beginning and when changing */}
+              <p>Please set or update your funding type below.</p>
+                {/* Thank you for using the Budget Calculator!  */}
 
                 <Form.Row>
                     <Form.Group className="initial-info">
@@ -60,7 +64,7 @@ class BCWelcomeModal extends Component {
                 <input type="hidden" name="redcap_csrf_token" value="" />
             </Modal.Body>
             <Modal.Footer>
-              <Button id="blue" disabled={! this.state.buttonActive} type="submit">Create New Budget</Button>
+              <Button id="blue" disabled={! this.state.buttonActive} type="submit">Set Rate</Button>
             </Modal.Footer>
           </Form>
 

--- a/bcclient/src/lib/bc/components/budgetcalculator/BCWelcomeModal.jsx
+++ b/bcclient/src/lib/bc/components/budgetcalculator/BCWelcomeModal.jsx
@@ -3,6 +3,7 @@ import Modal from "react-bootstrap/Modal";
 import Button from 'react-bootstrap/Button';
 import Form from 'react-bootstrap/Form';
 import FormCheck from 'react-bootstrap/FormCheck';
+import { bcConfig } from '../../js/config';
 
 class BCWelcomeModal extends Component {
 
@@ -21,7 +22,7 @@ class BCWelcomeModal extends Component {
 
   handleSubmit = (e) => {
     e.preventDefault();
-    this.state.setFundingType(e, this.selection.current.value);
+    this.state.setFundingType(e, this.selection.current.value === bcConfig.fundingLabels[0] ? 'industry_rate' : 'federal_rate');
     this.state.welcomeCallback( this.selection.current.value );
     this.setState({showWelcome: false})
 
@@ -29,14 +30,17 @@ class BCWelcomeModal extends Component {
 
   render() { 
     
-    
+    const optionRows = bcConfig.fundingLabels.map( label => {
+      return <option key={label} value={label}>{label}</option>
+    })
+
     return (
       <Modal id="welcomeModal" centered backdrop="static" show={this.props.showWelcome} aria-labelledby="welcomeModal" aria-hidden="true">
           <div role="document">
             <Form id="welcomeForm" onSubmit={this.handleSubmit}>
             <Modal.Body>
-              {/* reword this for using it both at the beginning and when changing */}
               <p>Please set or update your funding type below.</p>
+              {/* reword this for using it both at the beginning and when changing */}
                 {/* Thank you for using the Budget Calculator!  */}
 
                 <Form.Row>
@@ -46,8 +50,9 @@ class BCWelcomeModal extends Component {
                       </Form.Label>
                       <Form.Control className="info-field" as="select" id="fundingType" name="fundingType" ref={this.selection} required>
                         <option value="">---Select---</option>
-                        <option value="industry_rate">Industry Rate</option>
-                        <option value="federal_rate">Federal Rate</option>
+                        {optionRows}
+                        {/* <option value="industry_rate">Industry Rate</option>
+                        <option value="federal_rate">Federal Rate</option> */}
                       </Form.Control>
                     </Form.Group>
                 </Form.Row>

--- a/bcclient/src/lib/bc/components/budgetcalculator/BudgetCalculator.jsx
+++ b/bcclient/src/lib/bc/components/budgetcalculator/BudgetCalculator.jsx
@@ -79,7 +79,7 @@ class BudgetCalculator extends Component {
             <br />
 
             <BCServicesTable />
-              <><small>Current funding type: {this.props.bcstate.fundingType}</small></>
+              <><small>Current funding type: {this.props.bcstate.fundingType==='federal_rate'? 'Half Rate' : 'Full Rate'}</small></>
 
 
             <div id="disclaimer">

--- a/bcclient/src/lib/bc/components/budgetcalculator/BudgetCalculator.jsx
+++ b/bcclient/src/lib/bc/components/budgetcalculator/BudgetCalculator.jsx
@@ -16,7 +16,8 @@ class BudgetCalculator extends Component {
       showInfo: false,
       showSave: false,
       showInfoSubjectCount: "",
-      showInfoVisitCount: ""
+      showInfoVisitCount: "",
+      welcomeOpenCallback: this.props.welcomeOpenCallback
     }
   }
 
@@ -46,6 +47,9 @@ class BudgetCalculator extends Component {
   }
 
   handleHideWelcome = () => this.setState({showWelcome: false});
+  handleShowWelcome = () => {
+    this.state.welcomeOpenCallback()
+  };
 
   render() { 
     return ( 
@@ -68,12 +72,15 @@ class BudgetCalculator extends Component {
               handleHideSave={this.handleHideSave} />
 
             <BCNav 
-              showInfoCallback={this.showInfoCallback}  
+              showInfoCallback={this.showInfoCallback}
+              handleShowWelcome={this.handleShowWelcome}  
               bcstate={this.props.bcstate}/>
             <br />
             <br />
 
             <BCServicesTable />
+              <><small>Current funding type: {this.props.bcstate.fundingType}</small></>
+
 
             <div id="disclaimer">
               This is a work in progress and not representative of the final product. Pricing data is for testing purposes only.

--- a/bcclient/src/lib/bc/contexts/BudgetConsumerClinicalRows.jsx
+++ b/bcclient/src/lib/bc/contexts/BudgetConsumerClinicalRows.jsx
@@ -44,7 +44,7 @@ class BudgetClinicalRowsConsumer extends Component {
                           service={obj.service}
                           description={obj.service_description}
                           industryrate={obj.industry_rate}
-                          yourCost={obj.yourCost}
+                          yourCost={context.fundingType === 'federal_rate' ?  obj.federal_rate : obj.industry_rate}
                           federalrate={obj.federal_rate}
                           clinical={obj.clinical}
                           removeBCService={context.removeBCService}

--- a/bcclient/src/lib/bc/contexts/BudgetNONClinicalRowsConsumer.jsx
+++ b/bcclient/src/lib/bc/contexts/BudgetNONClinicalRowsConsumer.jsx
@@ -41,8 +41,8 @@ class BudgetNONClinicalRowsConsumer extends Component {
                           industryrate={obj.industry_rate}
                           federalrate={obj.federal_rate}
                           clinical={obj.clinical}
-                          totalCost={obj.totalCost}
-                          yourCost={obj.yourCost}
+                          totalCost={context.fundingType === 'federal_rate' ? (obj.federal_rate * obj.quantity) : (obj.industry_rate * obj.quantity)}
+                          yourCost={context.fundingType === 'federal_rate' ?  obj.federal_rate : obj.industry_rate}
                           quantity={obj.quantity}
                           perService={obj.per_service}
 

--- a/bcclient/src/lib/bc/contexts/BudgetProvider.jsx
+++ b/bcclient/src/lib/bc/contexts/BudgetProvider.jsx
@@ -500,13 +500,6 @@ class BudgetProvider extends Component {
     }
   }
 
-  // toggleFundingType = () => {
-  //   this.setState({
-  //     fundingType: this.state.fundingType === 'federal_rate' ? 'industry_rate' : 'federal_rate'
-  //   })
-  //   console.log('[provider] funding type changed to: ' + this.state.fundingType)
-  // }
-
 
   handleQtyCountChange = (rowId, value) => {
     let rowNotClinical;

--- a/bcclient/src/lib/bc/contexts/BudgetProvider.jsx
+++ b/bcclient/src/lib/bc/contexts/BudgetProvider.jsx
@@ -342,11 +342,11 @@ class BudgetProvider extends Component {
 
   csSetRowTotal = (rowId, bcrowsCopy) => {
 
-    let numberOfVisits = bcrowsCopy[rowId].visitCount.filter(v=>(v)).length;
+    // let numberOfVisits = bcrowsCopy[rowId].visitCount.filter(v=>(v)).length;
     let rowCostPerSubject = bcrowsCopy[rowId].costPerSubject;
     let subjectCount = bcrowsCopy[rowId].subjectCount;
 
-    let totalRowCost = rowCostPerSubject * numberOfVisits * subjectCount;
+    let totalRowCost = rowCostPerSubject * subjectCount;
 
     bcrowsCopy[rowId].totalCost = totalRowCost;
     return bcrowsCopy;

--- a/bcclient/src/lib/bc/contexts/BudgetProvider.jsx
+++ b/bcclient/src/lib/bc/contexts/BudgetProvider.jsx
@@ -494,10 +494,10 @@ class BudgetProvider extends Component {
    */
   setFundingType = (e, fundingType) => {
     this.setState({ fundingType: fundingType });
-    // if (this.state.bcrows !== {}) {
-    //   this.cshUpdateAllClinicalTotals();
-    //   this.ncsCalculateNonclinicalTotals();
-    // }
+    if (this.state.bcrows !== {}) {
+      this.cshUpdateAllClinicalTotals();
+      this.ncsCalculateNonclinicalTotals();
+    }
   }
 
   // toggleFundingType = () => {

--- a/bcclient/src/lib/bc/contexts/BudgetProvider.jsx
+++ b/bcclient/src/lib/bc/contexts/BudgetProvider.jsx
@@ -4,6 +4,8 @@ import BudgetContext from './BudgetContext';
 import BudgetUtils from '../js/BudgetUtils';
 import PerServiceData from '../js/PerServiceData';
 
+import {bcConfig} from '../js/config';
+
 class BudgetProvider extends Component {
   
   constructor(props) {
@@ -16,7 +18,7 @@ class BudgetProvider extends Component {
         bcimShowInfoVisitCount: 0, // Number of columns of visits that can be selected. The info modal populates this field.
         bcInfoModalNeeded: false, // when needed, the ID of the row that needs the info is populated in this attribute.
 
-        fundingType: '', // Determines the "Your Cost" column. Set by the BCWelcomeModal.
+        fundingType: bcConfig.presetFundingType ? bcConfig.presetFundingType : '', // Determines the "Your Cost" column. Set by the BCWelcomeModal.
         bcrows: {}, // All clinical and non-clinical rows for virtual DOM to display. Authoritative row state **SHOULD BE** preserved here, and not in the row components.
         
         // nonclinicalRowsTotal: {}, // calculated totals associated with rows' ID //TODO: Old design. Planning to refactor into bcrows
@@ -41,7 +43,8 @@ class BudgetProvider extends Component {
     this.isClinical = bu.isClinical;
     this.isNotClinical = bu.isNotClinical;
   }
-
+  
+  
   //////////////////////////////////////////
   //
   // BEGIN: Per Service Data
@@ -272,7 +275,7 @@ class BudgetProvider extends Component {
     });
 
   }
-
+  
   /**
    * Updates a row's check button, then calls the fuction to set the total per subject.
    */
@@ -491,7 +494,19 @@ class BudgetProvider extends Component {
    */
   setFundingType = (e, fundingType) => {
     this.setState({ fundingType: fundingType });
+    // if (this.state.bcrows !== {}) {
+    //   this.cshUpdateAllClinicalTotals();
+    //   this.ncsCalculateNonclinicalTotals();
+    // }
   }
+
+  // toggleFundingType = () => {
+  //   this.setState({
+  //     fundingType: this.state.fundingType === 'federal_rate' ? 'industry_rate' : 'federal_rate'
+  //   })
+  //   console.log('[provider] funding type changed to: ' + this.state.fundingType)
+  // }
+
 
   handleQtyCountChange = (rowId, value) => {
     let rowNotClinical;
@@ -503,7 +518,7 @@ class BudgetProvider extends Component {
 
       updatedBCRows[rowId].quantity = value;
 
-      if (rowNotClinical) {
+      if (rowNotClinical) { // this might cause an issue with rate changing for yourCost
         updatedBCRows[rowId].totalCost = updatedBCRows[rowId].yourCost * updatedBCRows[rowId].quantity;
       }
       else {
@@ -629,12 +644,14 @@ class BudgetProvider extends Component {
   }
 
   render() { 
+    
     return ( 
       <BudgetContext.Provider
         value={{
           bcstate: this.state,
           bcrows: this.state.bcrows,
           fundingType: this.state.fundingType,
+          // toggleFundingType: this.toggleFundingType,
 
           nonclinicalTotals: this.state.nonclinicalTotals,
           clinicalTotals: this.state.clinicalTotals,

--- a/bcclient/src/lib/bc/js/config.js
+++ b/bcclient/src/lib/bc/js/config.js
@@ -23,5 +23,9 @@ export const bcConfig = {
   /* In order to allow users to default to a funding type, enter the name of the funding type 
   - in this case, 'federal_rate' or 'industry_rate' 
   OR leave blank to allow user to set funding type for each use */
-  presetFundingType: ''
+  presetFundingType: '',
+  /* Configure UI-only labels here:
+    list the full cost rate first, as the first index of this array becomes 'industry_rate'
+    once the rate is set with BCWelcomeModal */ 
+  fundingLabels: ['Full Rate', 'Half Rate']
   };

--- a/bcclient/src/lib/bc/js/config.js
+++ b/bcclient/src/lib/bc/js/config.js
@@ -11,12 +11,17 @@
 
 export const bcConfig = { 
   //urlBase: 'https://redcap-dev.ccts.utah.edu', //example base URL
-  urlBase: 'http://2019augredcap:8888', 
+  // urlBase: 'http://2019augredcap:8888', 
+  urlBase: 'http://april20redcap:8888', 
 
-  //urlPathToREDCap: '', //usually a variation of '/redcap'
-  urlPathToREDCap: '/redcap',  //example example URL path to redcap
+  urlPathToREDCap: '', //usually a variation of '/redcap'
+  // urlPathToREDCap: '/redcap',  //example example URL path to redcap
 
   serviceCatalogApi: '/api/?NOAUTH&type=module&prefix=budget_calculator&page=api/service_catalog_api',
   
-  perServiceAPI: '/api/?NOAUTH&type=module&prefix=budget_calculator&page=api/per_service_api'
+  perServiceAPI: '/api/?NOAUTH&type=module&prefix=budget_calculator&page=api/per_service_api',
+  /* In order to allow users to default to a funding type, enter the name of the funding type 
+  - in this case, 'federal_rate' or 'industry_rate' 
+  OR leave blank to allow user to set funding type for each use */
+  presetFundingType: ''
   };


### PR DESCRIPTION
Allows funding type to be preset in config.js

--some of the additions below are a part of 'updating the funding rate' but shouldn't stop functionality--

NOTE: I did update routes/parameters in config.js to reflect my dev environment!